### PR TITLE
Add :release_name_from option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ set :deploy_via, :jenkins_artifact
 | `artifact_relative_path` | String | n | `nil` |
 | `artifact_compression_type` | (see below) | n | guessed by artifact URL |
 | `artifact_strip_level` | Numeric | n | `1` |
-| `release_name_from` | (see below) | n | `'build_at'` |
+| `release_name_from` | (see below) | n | `:build_at` |
 
 ### Supported compression types
 
@@ -59,10 +59,10 @@ set :deploy_via, :jenkins_artifact
 
 ### `release_name_from` option
 
-You can set either `'build_at'` (default) or `'deploy_at'` to this option.
+You can set either `:build_at` (default) or `:deploy_at` to this option.
 
 By default, this storategy will set release_name from the artifact's build timestamp.  This behavior is different from Capistrano's default.
-If you prefer Capistrano's default behavior (use current timestamp for release_name), set this option to `'deploy_at'`.
+If you prefer Capistrano's default behavior (use current timestamp for release_name), set this option to `:deploy_at`.
 
 ## Options exposed by capistrano-strategy-jenkins_artifact
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ set :deploy_via, :jenkins_artifact
 | `artifact_relative_path` | String | n | `nil` |
 | `artifact_compression_type` | (see below) | n | guessed by artifact URL |
 | `artifact_strip_level` | Numeric | n | `1` |
+| `release_name_from` | (see below) | n | `'build_at'` |
 
 ### Supported compression types
 
@@ -55,6 +56,13 @@ set :deploy_via, :jenkins_artifact
 * bzip2
 * xz
 * raw
+
+### `release_name_from` option
+
+You can set either `'build_at'`(default) or `'deploy_at'` to this option.
+
+By default, this storategy will set release_name from the artifact's build timestamp.  This behaviour is different from capistrano's default behaviour.
+If you prefer capistrano's default behaviour(use current timestamp for release_name), set this option to `'deploy_at'`.
 
 ## Options exposed by capistrano-strategy-jenkins_artifact
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ set :deploy_via, :jenkins_artifact
 
 ### `release_name_from` option
 
-You can set either `'build_at'`(default) or `'deploy_at'` to this option.
+You can set either `'build_at'` (default) or `'deploy_at'` to this option.
 
-By default, this storategy will set release_name from the artifact's build timestamp.  This behaviour is different from capistrano's default behaviour.
-If you prefer capistrano's default behaviour(use current timestamp for release_name), set this option to `'deploy_at'`.
+By default, this storategy will set release_name from the artifact's build timestamp.  This behavior is different from Capistrano's default.
+If you prefer Capistrano's default behavior (use current timestamp for release_name), set this option to `'deploy_at'`.
 
 ## Options exposed by capistrano-strategy-jenkins_artifact
 

--- a/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
+++ b/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
@@ -50,9 +50,9 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
   def deploy!
     dir_name = exists?(:is_multibranch_job) && fetch(:is_multibranch_job) ? fetch(:branch) : fetch(:build_project)
 
-    release_name_from = fetch(:release_name_from, 'build_at')
-    if release_name_from != 'build_at' && release_name_from != 'deploy_at' then
-      abort ':release_name_from must be either `build_at` or `deploy_at`'
+    release_name_from = fetch(:release_name_from, :build_at)
+    if release_name_from != :build_at && release_name_from != :deploy_at then
+      abort ':release_name_from must be either `:build_at` or `:deploy_at`'
     end
 
     jenkins_origin = fetch(:jenkins_origin) or abort ":jenkins_origin configuration must be defined"
@@ -86,7 +86,7 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
       tar_opts << "--strip-components=#{strip_level}"
     end
 
-    if release_name_from == 'build_at' then
+    if release_name_from == :build_at then
       set(:release_name, build_at.strftime('%Y%m%d%H%M%S'))
     end
     set(:release_path, "#{fetch(:releases_path)}/#{fetch(:release_name)}")

--- a/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
+++ b/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
@@ -51,7 +51,7 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
     dir_name = exists?(:is_multibranch_job) && fetch(:is_multibranch_job) ? fetch(:branch) : fetch(:build_project)
 
     release_name_from = fetch(:release_name_from, :build_at)
-    if release_name_from != :build_at && release_name_from != :deploy_at then
+    if release_name_from != :build_at && release_name_from != :deploy_at
       abort ':release_name_from must be either `:build_at` or `:deploy_at`'
     end
 
@@ -86,7 +86,7 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
       tar_opts << "--strip-components=#{strip_level}"
     end
 
-    if release_name_from == :build_at then
+    if release_name_from == :build_at
       set(:release_name, build_at.strftime('%Y%m%d%H%M%S'))
     end
     set(:release_path, "#{fetch(:releases_path)}/#{fetch(:release_name)}")

--- a/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
+++ b/lib/capistrano/recipes/deploy/strategy/jenkins_artifact.rb
@@ -50,11 +50,16 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
   def deploy!
     dir_name = exists?(:is_multibranch_job) && fetch(:is_multibranch_job) ? fetch(:branch) : fetch(:build_project)
 
+    release_name_from = fetch(:release_name_from, 'build_at')
+    if release_name_from != 'build_at' && release_name_from != 'deploy_at' then
+      abort ':release_name_from must be either `build_at` or `deploy_at`'
+    end
+
     jenkins_origin = fetch(:jenkins_origin) or abort ":jenkins_origin configuration must be defined"
     client = JenkinsApi::Client.new(server_url: jenkins_origin.to_s)
 
     last_successful_build = client.job.get_last_successful_build(dir_name)
-    deploy_at = Time.at(last_successful_build['timestamp'] / 1000)
+    build_at = Time.at(last_successful_build['timestamp'] / 1000)
 
     set(:artifact_url) do
       artifact_finder = exists?(:artifact_relative_path) ?
@@ -81,7 +86,9 @@ class ::Capistrano::Deploy::Strategy::JenkinsArtifact < ::Capistrano::Deploy::St
       tar_opts << "--strip-components=#{strip_level}"
     end
 
-    set(:release_name, deploy_at.strftime('%Y%m%d%H%M%S'))
+    if release_name_from == 'build_at' then
+      set(:release_name, build_at.strftime('%Y%m%d%H%M%S'))
+    end
     set(:release_path, "#{fetch(:releases_path)}/#{fetch(:release_name)}")
     set(:latest_release, fetch(:release_path))
 


### PR DESCRIPTION
# Current behavior

## Capistrano default

release_name is taken from current timestamp as `Time.now.utc`

## This strategy

release_name is taken from `Time.at(last_successful_build['timestamp'] / 1000)`

# Changes introducing

By adding `:release_name_from` option, users can choose which way to decide release_name.  (Default behavior will not change.)